### PR TITLE
Update pytorch-lightning version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ffmpeg
 prefetch_generator
 librosa==0.8.0
 omegaconf==2.0.6
-pytorch_lightning==1.1.6
+pytorch_lightning==1.3.8


### PR DESCRIPTION
Current version throws `Batch not found` error. 

It is resolved in newer versions.